### PR TITLE
fix internationalization issue while calling nmcli and then grepping the yes word

### DIFF
--- a/network-tester.sh
+++ b/network-tester.sh
@@ -73,7 +73,7 @@ echo "Driver: $DRIVER" >> "$IW_LOG"
 echo "---------------------------" >> "$IW_LOG"
 
 # Get the active WiFi interface name
-interface=$(nmcli -t -f active,device d wifi list | grep '^yes' | cut -d':' -f2)
+interface=$(LC_ALL=en_US.utf8 nmcli -t -f active,device d wifi list | grep '^yes' | cut -d':' -f2)
 echo -e "\n        \033[1;33mInterface:\033[0m $interface"
 
 echo "Monitoring WiFi on interface $interface for $MONITOR_DURATION seconds. Logs are being saved to $IW_LOG and $PING_LOG."


### PR DESCRIPTION
The output returned by `nmcli` is localized, i.e. the output depends on the language of current user executing it. Grepping "yes" in the output will fail if the current user language is not English:

```
$  LC_ALL=fr_FR.UTF-8 nmcli -t -f active,device d wifi list
non:wlp1s0
non:wlp1s0
non:wlp1s0
oui:wlp1s0
non:wlp1s0
```

This commit sets the language to English when calling `nmcli` so the word "yes" can be successfully grepped.

See https://networkmanager.pages.freedesktop.org/NetworkManager/NetworkManager/nmcli.html > Internationalization notes

Fixes #3 

 